### PR TITLE
refactor: extract inline object types to named interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Refactored inline object type definitions to named interfaces for better code organization:
+  - Added `ModifierValidationResult` interface for modifier validation
+  - Added `ThemeTokenSuggestion` interface for theme token suggestions
+  - Added `StringWithDistance` interface for similarity calculations
+  - Added `TokenSuggestion` interface for token scoring
+
 ## [0.2.1] - 2025-07-01
 
 ### Added

--- a/src/rules/prefer-theme-tokens.ts
+++ b/src/rules/prefer-theme-tokens.ts
@@ -76,6 +76,14 @@ function getPropertyCategory(property: string): string | undefined {
   return propertyMappings[property] || undefined;
 }
 
+/**
+ * Represents a suggestion to use a theme token
+ */
+interface ThemeTokenSuggestion {
+  category: string
+  possibleToken?: string
+}
+
 // Define the rule options type
 type PreferThemeTokensOptions = [{
   categories?: string[]
@@ -196,7 +204,7 @@ export const preferThemeTokens: CSSRuleDefinition<{
     function shouldUseToken(
       property: string,
       value: string,
-    ): { category: string; possibleToken?: string } | undefined {
+    ): ThemeTokenSuggestion | undefined {
       // Check color values
       if (isColorValue(value)) {
         const category = getPropertyCategory(property);

--- a/src/rules/valid-modifier-syntax.ts
+++ b/src/rules/valid-modifier-syntax.ts
@@ -11,11 +11,7 @@ import { extractUtilitiesFromApply, parseUtilityClass } from '../utils/tailwind'
  * @param modifier - The full modifier string including brackets
  * @returns Validation result with error details if invalid
  */
-function validateArbitraryModifier(modifier: string): {
-  valid: boolean
-  messageId?: string
-  reason?: string
-} {
+function validateArbitraryModifier(modifier: string): ModifierValidationResult {
   const content = modifier.slice(1, -1);
 
   // Check for nested brackets - simple check for double brackets
@@ -61,6 +57,16 @@ function validateArbitraryModifier(modifier: string): {
 }
 
 /**
+ * Result of validating a modifier
+ */
+interface ModifierValidationResult {
+  valid: boolean
+  messageId?: string
+  reason?: string
+  fix?: string
+}
+
+/**
  * Validates parameterized modifiers (e.g., nth-child(3), nth-last-of-type(2n+1))
  *
  * @param name - The modifier name (e.g., 'nth-child')
@@ -70,11 +76,7 @@ function validateArbitraryModifier(modifier: string): {
 function validateParameterizedModifier(
   name: string,
   param: string,
-): {
-    valid: boolean
-    messageId?: string
-    reason?: string
-  } {
+): ModifierValidationResult {
   const validParameterized = [
     'nth-child',
     'nth-last-child',
@@ -290,12 +292,7 @@ export const validModifierSyntax: CSSRuleDefinition<{
       },
     };
 
-    function validateModifier(modifier: string): {
-      valid: boolean
-      messageId?: string
-      reason?: string
-      fix?: string
-    } {
+    function validateModifier(modifier: string): ModifierValidationResult {
       // Check for empty modifier
       if (modifier === '') {
         return {

--- a/src/utils/at-rules.ts
+++ b/src/utils/at-rules.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable unicorn/no-null -- Required to match @eslint/css-tree types */
 
-import type { AtRuleSyntax } from './types';
+import type { AtRuleSyntax, StringWithDistance } from './types';
 
 /**
  * Configuration for Tailwind v4 at-rules with their syntax
@@ -287,11 +287,13 @@ function findSimilarStrings(
   candidates: string[],
   maxDistance: number,
 ): string[] {
-  return candidates
+  const candidatesWithDistance: StringWithDistance[] = candidates
     .map(candidate => ({
       value: candidate,
       distance: levenshteinDistance(input.toLowerCase(), candidate.toLowerCase()),
-    }))
+    }));
+
+  return candidatesWithDistance
     .filter(item => item.distance <= maxDistance && item.distance > 0)
     .sort((a, b) => a.distance - b.distance)
     .map(item => item.value);

--- a/src/utils/css-properties.ts
+++ b/src/utils/css-properties.ts
@@ -2,6 +2,8 @@
  * CSS property validation utilities
  */
 
+import type { StringWithDistance } from './types';
+
 /**
  * Standard CSS properties with their expected value types
  * Based on CSS specifications and common browser support
@@ -429,11 +431,13 @@ function findSimilarStrings(
   candidates: string[],
   maxDistance: number,
 ): string[] {
-  return candidates
+  const candidatesWithDistance: StringWithDistance[] = candidates
     .map(candidate => ({
       value: candidate,
       distance: levenshteinDistance(input.toLowerCase(), candidate.toLowerCase()),
-    }))
+    }));
+
+  return candidatesWithDistance
     .filter(item => item.distance <= maxDistance && item.distance > 0)
     .sort((a, b) => a.distance - b.distance)
     .map(item => item.value);

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -12,6 +12,14 @@ export interface ThemeValue {
 }
 
 /**
+ * Represents a theme token with similarity score
+ */
+interface TokenSuggestion {
+  token: string
+  score: number
+}
+
+/**
  * Extract theme values from the CSS AST
  */
 export function extractThemeValues(ast: StyleSheetPlain, sourceText: string): Map<string, ThemeValue> {
@@ -174,7 +182,7 @@ export function suggestSimilarTokens(
   maxSuggestions: number = 3,
 ): string[] {
   const normalizedPath = path.toLowerCase().replaceAll(/[.-]/g, '');
-  const suggestions: Array<{ token: string; score: number }> = [];
+  const suggestions: TokenSuggestion[] = [];
 
   for (const [token] of themeValues) {
     const normalizedToken = token.toLowerCase().replaceAll(/[.-]/g, '');

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -9,3 +9,12 @@ import type { SyntaxConfig } from '@eslint/css-tree';
 export type AtRuleSyntax = NonNullable<SyntaxConfig['atrules']>[string];
 
 export { type SyntaxConfig } from '@eslint/css-tree';
+
+/**
+ * Represents a string value with its distance score
+ * Used for similarity calculations
+ */
+export interface StringWithDistance {
+  value: string
+  distance: number
+}


### PR DESCRIPTION
## Summary
- Extract inline object type definitions to named interfaces for better code organization
- Improve type reusability across the codebase

## Changes
- Add `ModifierValidationResult` interface for modifier validation functions
- Add `ThemeTokenSuggestion` interface for theme token suggestions  
- Add `StringWithDistance` interface in shared types for similarity calculations
- Add `TokenSuggestion` interface for token scoring
- Update all affected functions to use the new interfaces

## Benefits
- Better code organization with named types
- Improved reusability of common type patterns
- More maintainable and consistent codebase
- Easier to understand function signatures

## Test plan
- [ ] All existing tests pass
- [ ] TypeScript compilation succeeds
- [ ] No functional changes, only type refactoring