### PR TITLE
fix: address code review feedback for no-invalid-named-grid-areas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- `no-invalid-named-grid-areas` - Improved variable naming and added tests for
+  `grid` shorthand property
+
 ## [0.2.3] - 2025-07-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.2.4] - 2025-07-02
+
 ### Fixed
 
 - `no-invalid-named-grid-areas` - Improved variable naming and added tests for

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,4 +10,24 @@ export default defineConfig({
   rules: {
     'markdownlint/md013': ['error', { line_length: 80, tables: false }],
   },
+}, {
+  files: ['**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+  rules: {
+    'unicorn/prevent-abbreviations': ['error', {
+      replacements: {
+        props: false,
+        prop: false,
+        pkg: false,
+        utils: false,
+        fn: false,
+        param: false,
+        vars: false,
+      },
+      allowList: {
+        i: true,
+        j: true,
+        k: true,
+      },
+    }],
+  },
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/eslint-plugin-tailwindcss",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "description": "ESLint plugin for Tailwind CSS v4 with advanced linting rules",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/src/__tests__/rules/no-invalid-named-grid-areas.test.ts
+++ b/src/__tests__/rules/no-invalid-named-grid-areas.test.ts
@@ -74,6 +74,24 @@ describe('no-invalid-named-grid-areas', () => {
       // Valid dot tokens (empty cells)
       { code: '.grid { grid-template-areas: ". a a" "b b ."; }' },
       { code: '.grid { grid-template-areas: "... a a" "b b ..."; }' },
+
+      // grid shorthand property
+      {
+        code: String.raw`.grid {
+          grid:
+            "a a a" 40px
+            "b c c" 40px
+            "b c c" 40px / 1fr 1fr 1fr;
+        }`,
+      },
+      {
+        code: String.raw`.grid {
+          grid:
+            ". header header ." minmax(5rem, 1fr)
+            "sidebar main main ." 1fr
+            ". footer footer ." minmax(5rem, 1fr) / 1fr 1fr 1fr 1fr;
+        }`,
+      },
     ],
 
     invalid: [
@@ -285,6 +303,61 @@ describe('no-invalid-named-grid-areas', () => {
             column: 13,
             endLine: 5,
             endColumn: 25,
+          },
+        ],
+      },
+
+      // grid shorthand with empty area
+      {
+        code: String.raw`.grid {
+          grid:
+            "" 40px
+            "b c c" 40px / 1fr 1fr 1fr;
+        }`,
+        errors: [
+          {
+            messageId: 'emptyGridArea',
+            line: 3,
+            column: 13,
+            endLine: 3,
+            endColumn: 15,
+          },
+        ],
+      },
+
+      // grid shorthand with uneven columns
+      {
+        code: String.raw`.grid {
+          grid:
+            "a a a" 40px
+            "b c" 40px / 1fr 1fr 1fr;
+        }`,
+        errors: [
+          {
+            messageId: 'unevenGridArea',
+            line: 4,
+            column: 13,
+            endLine: 4,
+            endColumn: 18,
+          },
+        ],
+      },
+
+      // grid shorthand with non-rectangular area
+      {
+        code: String.raw`.grid {
+          grid:
+            "a a b" 40px
+            "c a a" 40px / 1fr 1fr 1fr;
+        }`,
+        errors: [
+          {
+            messageId: 'nonRectangularGridArea',
+            data: { name: 'a' },
+            line: 4,
+            column: 13,
+            endLine: 4,
+            endColumn: 20,
           },
         ],
       },

--- a/src/rules/no-conflicting-utilities.ts
+++ b/src/rules/no-conflicting-utilities.ts
@@ -113,9 +113,9 @@ function findConflictingUtilities(utilities: string[]): Array<{
 
     // Check each pair of utilities
     for (let i = 0; i < utils.length - 1; i++) {
-      for (let index = i + 1; index < utils.length; index++) {
+      for (let j = i + 1; j < utils.length; j++) {
         const utility1 = utils[i];
-        const utility2 = utils[index];
+        const utility2 = utils[j];
 
         if (doUtilitiesConflict(utility1, utility2)) {
           conflicts.push({


### PR DESCRIPTION
## Summary

This PR addresses the code review feedback from PR #33:

- ✅ Use `i`, `j`, `k` convention for nested loop variables instead of `index`
- ✅ Add comprehensive tests for `grid` shorthand property support
- ✅ Add comments documenting error reporting priority in the rule
- ✅ Configure ESLint to allow common abbreviations (props, prop, pkg, utils, fn, param, vars)
- ✅ Apply the same loop variable convention to `no-conflicting-utilities` rule

## Changes

1. **Variable naming improvements**: Updated nested loops to use `i`, `j`, `k` convention as recommended
2. **Test coverage**: Added 3 new test cases for `grid` shorthand property validation
3. **Documentation**: Added inline comments explaining the error reporting priority (empty → uneven → non-rectangular)
4. **ESLint configuration**: Added abbreviation allowlist to maintain code consistency

## Test plan

- [x] All existing tests pass
- [x] New tests for `grid` shorthand property pass
- [x] `pnpm prepack` runs successfully
- [x] No linting errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the no-invalid-named-grid-areas rule, especially for the grid shorthand property.
  * Enhanced error reporting for grid area validation.

* **Tests**
  * Added new test cases to cover grid shorthand scenarios, ensuring more robust validation.

* **Chores**
  * Updated changelog with latest fixes.
  * Bumped package version to 0.2.4.
  * Refined ESLint configuration for abbreviation prevention and variable naming clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->