### PR TITLE
chore(deps): @poupe/eslint-config 0.9.1, release v0.3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   make:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- **ci**: Add `pull-requests: write` permission to build workflow
+  so pkg-pr-new can post install comments on PRs
+
 ## [0.3.0] - 2026-04-06
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-04-07
+
 ### Changed
 
 - **deps**: `@poupe/eslint-config` ~0.9.0 → ~0.9.1 — ships

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- **deps**: `@poupe/eslint-config` ~0.9.0 → ~0.9.1 — ships
+  perfectionist v5 with `partitionByNewLine` enabled on
+  `sort-exports`/`sort-named-exports`, allowing the local
+  overrides in `eslint.config.mjs` to be removed
+- **deps**: Drop direct `eslint-plugin-perfectionist` devDep —
+  provided transitively by `@poupe/eslint-config` (now v5)
+
 ### Fixed
 
 - **ci**: Add `pull-requests: write` permission to build workflow

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,20 +13,6 @@ export default defineConfig({
 }, {
   files: ['**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
   rules: {
-    // TODO: remove after eslint-config enables partitionByNewLine
-    'perfectionist/sort-exports': ['error', {
-      type: 'natural',
-      order: 'asc',
-      ignoreCase: true,
-      partitionByNewLine: true,
-    }],
-    'perfectionist/sort-named-exports': ['error', {
-      type: 'natural',
-      order: 'asc',
-      ignoreCase: true,
-      groupKind: 'mixed',
-      partitionByNewLine: true,
-    }],
     'unicorn/prevent-abbreviations': ['error', {
       replacements: {
         props: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/eslint-plugin-tailwindcss",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "description": "ESLint plugin for Tailwind CSS v4 with advanced linting rules",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/package.json
+++ b/package.json
@@ -63,12 +63,11 @@
   },
   "devDependencies": {
     "@kagal/cross-test": "~0.1.3",
-    "@poupe/eslint-config": "~0.9.0",
+    "@poupe/eslint-config": "~0.9.1",
     "@types/eslint": "^9.6.1",
     "@types/node": "^22.19.15",
     "@vitest/coverage-v8": "~4.1.0",
     "eslint": "^9.39.4",
-    "eslint-plugin-perfectionist": "^4.15.1",
     "npm-run-all2": "^8.0.4",
     "pkg-pr-new": "~0.0.66",
     "publint": "^0.3.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: ~0.1.3
         version: 0.1.3
       '@poupe/eslint-config':
-        specifier: ~0.9.0
-        version: 0.9.0(@vue/compiler-sfc@3.5.32)(jiti@2.6.1)(typescript@5.9.3)(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.6.1)))
+        specifier: ~0.9.1
+        version: 0.9.1(@vue/compiler-sfc@3.5.32)(jiti@2.6.1)(typescript@5.9.3)(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.6.1)))
       '@types/eslint':
         specifier: ^9.6.1
         version: 9.6.1
@@ -39,9 +39,6 @@ importers:
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.6.1)
-      eslint-plugin-perfectionist:
-        specifier: ^4.15.1
-        version: 4.15.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       npm-run-all2:
         specifier: ^8.0.4
         version: 8.0.4
@@ -457,11 +454,11 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@poupe/eslint-config@0.9.0':
-    resolution: {integrity: sha512-l/L7di4V4OKwKK1+PvJEP10VXrEuf+iIzovMN6rWg9MjCji0CxX6+VlFGszH4oYXzrKzm7I75Cpy1nPgs70npQ==}
+  '@poupe/eslint-config@0.9.1':
+    resolution: {integrity: sha512-RMT/m1R+jLXQaDpE5Cm9NRBsapWNXiF3qk/K2qs+WvQDmQ0YNzMGXtchCs5IttkOS+pwN1svSN3WHxpJSFozFA==}
     engines: {node: '>= 20.20.2', pnpm: '>= 10.33.0'}
     peerDependencies:
-      '@vue/compiler-sfc': ^3.3.0
+      '@vue/compiler-sfc': ^3.5.32
 
   '@publint/pack@0.1.4':
     resolution: {integrity: sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==}
@@ -1293,11 +1290,11 @@ packages:
     peerDependencies:
       eslint: '>=7.5.0'
 
-  eslint-plugin-perfectionist@4.15.1:
-    resolution: {integrity: sha512-MHF0cBoOG0XyBf7G0EAFCuJJu4I18wy0zAoT1OHfx2o6EOx1EFTIzr2HGeuZa1kDcusoX0xJ9V7oZmaeFd773Q==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  eslint-plugin-perfectionist@5.8.0:
+    resolution: {integrity: sha512-k8uIptWIxkUclonCFGyDzgYs9NI+Qh0a7cUXS3L7IYZDEsjXuimFBVbxXPQQngWqMiaxJRwbtYB4smMGMqF+cw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
     peerDependencies:
-      eslint: '>=8.45.0'
+      eslint: ^8.45.0 || ^9.0.0 || ^10.0.0
 
   eslint-plugin-tsdoc@0.5.2:
     resolution: {integrity: sha512-BlvqjWZdBJDIPO/YU3zcPCF23CvjYT3gyu63yo6b609NNV3D1b6zceAREy2xnweuBoDpZcLNuPyAUq9cvx6bbQ==}
@@ -2929,7 +2926,7 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@poupe/eslint-config@0.9.0(@vue/compiler-sfc@3.5.32)(jiti@2.6.1)(typescript@5.9.3)(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.6.1)))':
+  '@poupe/eslint-config@0.9.1(@vue/compiler-sfc@3.5.32)(jiti@2.6.1)(typescript@5.9.3)(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.6.1)))':
     dependencies:
       '@eslint/css': 1.1.0
       '@eslint/js': 9.39.4
@@ -2941,7 +2938,7 @@ snapshots:
       eslint-merge-processors: 2.0.0(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsonc: 3.1.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-markdownlint: 0.9.0(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-perfectionist: 4.15.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      eslint-plugin-perfectionist: 5.8.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-tsdoc: 0.5.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-unicorn: 63.0.0(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-vue: 10.8.0(@stylistic/eslint-plugin@5.10.0(eslint@9.39.4(jiti@2.6.1)))(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.6.1)))
@@ -3212,8 +3209,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.56.1(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.58.0
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -3768,9 +3765,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-perfectionist@4.15.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
+  eslint-plugin-perfectionist@5.8.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/types': 8.58.0
       '@typescript-eslint/utils': 8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       natural-orderby: 5.0.0

--- a/src/__tests__/utils/ast.test.ts
+++ b/src/__tests__/utils/ast.test.ts
@@ -12,8 +12,8 @@ interface MockAST {
 
 // Mock source code type
 interface MockSourceCode extends Partial<SourceCode> {
-  text?: string
   ast?: MockAST
+  text?: string
 }
 
 // Helper function moved to outer scope

--- a/src/rules/consistent-spacing.ts
+++ b/src/rules/consistent-spacing.ts
@@ -18,10 +18,10 @@ interface SpacingOptions {
  * Location information for a position in the source code
  */
 interface LocationInfo {
-  /** Line number (1-based) */
-  line: number
   /** Column number (0-based) */
   column: number
+  /** Line number (1-based) */
+  line: number
   /** Character offset from start of file */
   offset: number
 }
@@ -32,10 +32,10 @@ interface LocationInfo {
 interface DeclarationInfo {
   /** The declaration AST node */
   node: DeclarationPlain
-  /** Length of the property name */
-  propertyLength: number
   /** Location where the property name ends */
   propertyEnd: LocationInfo
+  /** Length of the property name */
+  propertyLength: number
   /** Location where the value starts */
   valueStart: LocationInfo
 }
@@ -56,8 +56,8 @@ type ConsistentSpacingMessageIds =
   'unexpectedSpaceBeforeColon';
 
 export const consistentSpacing: CSSRuleDefinition<{
-  RuleOptions: ConsistentSpacingOptions
   MessageIds: ConsistentSpacingMessageIds
+  RuleOptions: ConsistentSpacingOptions
 }> = {
   meta: {
     type: 'layout',

--- a/src/rules/no-arbitrary-value-overuse.ts
+++ b/src/rules/no-arbitrary-value-overuse.ts
@@ -67,9 +67,9 @@ function shouldSuggestToken(value: string, utility: string): boolean {
 
 // Define the rule options type
 type NoArbitraryValueOveruseOptions = [{
+  allowedUtilities?: string[]
   maxPerFile?: number
   maxPerRule?: number
-  allowedUtilities?: string[]
 }];
 
 // Define the message IDs
@@ -80,8 +80,8 @@ type NoArbitraryValueOveruseMessageIds =
 
 // Define the rule with proper types
 export const noArbitraryValueOveruse: CSSRuleDefinition<{
-  RuleOptions: NoArbitraryValueOveruseOptions
   MessageIds: NoArbitraryValueOveruseMessageIds
+  RuleOptions: NoArbitraryValueOveruseOptions
 }> = {
   meta: {
     type: 'suggestion',
@@ -132,8 +132,8 @@ export const noArbitraryValueOveruse: CSSRuleDefinition<{
     let fileArbitraryCount = 0;
     const arbitraryValues: Array<{
       node: AtrulePlain
-      value: string
       utility: string
+      value: string
     }> = [];
 
     return {
@@ -149,8 +149,8 @@ export const noArbitraryValueOveruse: CSSRuleDefinition<{
 
         let ruleArbitraryCount = 0;
         const ruleArbitraryValues: Array<{
-          value: string
           utility: string
+          value: string
         }> = [];
 
         for (const utility of utilities) {

--- a/src/rules/no-conflicting-utilities.ts
+++ b/src/rules/no-conflicting-utilities.ts
@@ -94,14 +94,14 @@ function groupUtilitiesByProperty(
 }
 
 function findConflictingUtilities(utilities: string[]): Array<{
+  property: string
   utility1: string
   utility2: string
-  property: string
 }> {
   const conflicts: Array<{
+    property: string
     utility1: string
     utility2: string
-    property: string
   }> = [];
 
   // Group utilities by their affected CSS property
@@ -143,8 +143,8 @@ type NoConflictingUtilitiesMessageIds =
 
 // Define the rule with proper types
 export const noConflictingUtilities: CSSRuleDefinition<{
-  RuleOptions: NoConflictingUtilitiesOptions
   MessageIds: NoConflictingUtilitiesMessageIds
+  RuleOptions: NoConflictingUtilitiesOptions
 }> = {
   meta: {
     type: 'problem',

--- a/src/rules/no-duplicate-imports.ts
+++ b/src/rules/no-duplicate-imports.ts
@@ -26,8 +26,8 @@ type NoDuplicateImportsMessageIds = 'duplicateImport';
  * ```
  */
 export const noDuplicateImports: CSSRuleDefinition<{
-  RuleOptions: NoDuplicateImportsOptions
   MessageIds: NoDuplicateImportsMessageIds
+  RuleOptions: NoDuplicateImportsOptions
 }> = {
   meta: {
     type: 'problem',

--- a/src/rules/no-duplicate-reference.ts
+++ b/src/rules/no-duplicate-reference.ts
@@ -21,8 +21,8 @@ type NoDuplicateReferenceMessageIds = 'duplicateReference';
  * that each reference target is declared only once.
  */
 export const noDuplicateReference: CSSRuleDefinition<{
-  RuleOptions: NoDuplicateReferenceOptions
   MessageIds: NoDuplicateReferenceMessageIds
+  RuleOptions: NoDuplicateReferenceOptions
 }> = {
   meta: {
     type: 'problem',

--- a/src/rules/no-empty-blocks.ts
+++ b/src/rules/no-empty-blocks.ts
@@ -39,8 +39,8 @@ type NoEmptyBlocksMessageIds = 'emptyBlock';
  * ```
  */
 export const noEmptyBlocks: CSSRuleDefinition<{
-  RuleOptions: NoEmptyBlocksOptions
   MessageIds: NoEmptyBlocksMessageIds
+  RuleOptions: NoEmptyBlocksOptions
 }> = {
   meta: {
     type: 'suggestion',

--- a/src/rules/no-important.ts
+++ b/src/rules/no-important.ts
@@ -16,8 +16,8 @@ type NoImportantMessageIds = 'avoidImportant';
  * the natural cascade of CSS and makes styles harder to override.
  */
 export const noImportant: CSSRuleDefinition<{
-  RuleOptions: NoImportantOptions
   MessageIds: NoImportantMessageIds
+  RuleOptions: NoImportantOptions
 }> = {
   meta: {
     type: 'suggestion',

--- a/src/rules/no-invalid-at-rules.ts
+++ b/src/rules/no-invalid-at-rules.ts
@@ -21,8 +21,8 @@ type NoInvalidAtRulesMessageIds =
  * Rule to disallow invalid at-rule names and validate their structure
  */
 export const noInvalidAtRules: CSSRuleDefinition<{
-  RuleOptions: NoInvalidAtRulesOptions
   MessageIds: NoInvalidAtRulesMessageIds
+  RuleOptions: NoInvalidAtRulesOptions
 }> = {
   meta: {
     type: 'problem',

--- a/src/rules/no-invalid-named-grid-areas.ts
+++ b/src/rules/no-invalid-named-grid-areas.ts
@@ -87,8 +87,8 @@ function findNonRectangularAreas(grid: string[][]): GridAreaError[] {
  * All rows must have the same number of cell tokens.
  */
 export const noInvalidNamedGridAreas: CSSRuleDefinition<{
-  RuleOptions: NoInvalidNamedGridAreasOptions
   MessageIds: NoInvalidNamedGridAreasMessageIds
+  RuleOptions: NoInvalidNamedGridAreasOptions
 }> = {
   meta: {
     type: 'problem',

--- a/src/rules/no-invalid-properties.ts
+++ b/src/rules/no-invalid-properties.ts
@@ -17,8 +17,8 @@ type NoInvalidPropertiesMessageIds =
 
 // Define the rule with proper types
 export const noInvalidProperties: CSSRuleDefinition<{
-  RuleOptions: NoInvalidPropertiesOptions
   MessageIds: NoInvalidPropertiesMessageIds
+  RuleOptions: NoInvalidPropertiesOptions
 }> = {
   meta: {
     type: 'problem',

--- a/src/rules/prefer-theme-tokens.ts
+++ b/src/rules/prefer-theme-tokens.ts
@@ -97,8 +97,8 @@ type PreferThemeTokensMessageIds =
 
 // Define the rule with proper types
 export const preferThemeTokens: CSSRuleDefinition<{
-  RuleOptions: PreferThemeTokensOptions
   MessageIds: PreferThemeTokensMessageIds
+  RuleOptions: PreferThemeTokensOptions
 }> = {
   meta: {
     type: 'suggestion',

--- a/src/rules/require-reference-in-vue.ts
+++ b/src/rules/require-reference-in-vue.ts
@@ -19,8 +19,8 @@ type RequireReferenceInVueMessageIds = 'missingReference';
  * This rule ensures that Vue SFC <style> blocks include the \@reference directive.
  */
 export const requireReferenceInVue: CSSRuleDefinition<{
-  RuleOptions: RequireReferenceInVueOptions
   MessageIds: RequireReferenceInVueMessageIds
+  RuleOptions: RequireReferenceInVueOptions
 }> = {
   meta: {
     type: 'problem',

--- a/src/rules/use-baseline.ts
+++ b/src/rules/use-baseline.ts
@@ -28,8 +28,8 @@ type UseBaselineMessageIds =
  * Rule to enforce use of baseline (widely supported) CSS features
  */
 export const useBaseline: CSSRuleDefinition<{
-  RuleOptions: UseBaselineRuleOptions
   MessageIds: UseBaselineMessageIds
+  RuleOptions: UseBaselineRuleOptions
 }> = {
   meta: {
     type: 'problem',

--- a/src/rules/valid-apply-directive.ts
+++ b/src/rules/valid-apply-directive.ts
@@ -91,8 +91,8 @@ type ValidApplyDirectiveMessageIds =
 
 // Define the rule with proper types
 export const validApplyDirective: CSSRuleDefinition<{
-  RuleOptions: ValidApplyDirectiveOptions
   MessageIds: ValidApplyDirectiveMessageIds
+  RuleOptions: ValidApplyDirectiveOptions
 }> = {
   meta: {
     type: 'problem',

--- a/src/rules/valid-modifier-syntax.ts
+++ b/src/rules/valid-modifier-syntax.ts
@@ -60,10 +60,10 @@ function validateArbitraryModifier(modifier: string): ModifierValidationResult {
  * Result of validating a modifier
  */
 interface ModifierValidationResult {
-  valid: boolean
+  fix?: string
   messageId?: string
   reason?: string
-  fix?: string
+  valid: boolean
 }
 
 /**
@@ -122,8 +122,8 @@ type ValidModifierSyntaxMessageIds =
 
 // Define the rule with proper types
 export const validModifierSyntax: CSSRuleDefinition<{
-  RuleOptions: ValidModifierSyntaxOptions
   MessageIds: ValidModifierSyntaxMessageIds
+  RuleOptions: ValidModifierSyntaxOptions
 }> = {
   meta: {
     type: 'problem',

--- a/src/rules/valid-theme-function.ts
+++ b/src/rules/valid-theme-function.ts
@@ -24,8 +24,8 @@ type ValidThemeFunctionMessageIds =
 
 // Define the rule with proper types
 export const validThemeFunction: CSSRuleDefinition<{
-  RuleOptions: ValidThemeFunctionOptions
   MessageIds: ValidThemeFunctionMessageIds
+  RuleOptions: ValidThemeFunctionOptions
 }> = {
   meta: {
     type: 'problem',

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,13 +40,13 @@ type CSSNodeVisitor = {
  * A visitor for CSS nodes.
  */
 export interface CSSRuleVisitor
-  extends RuleVisitor,
-  Partial<WithExit<CSSNodeVisitor>> {}
+  extends Partial<WithExit<CSSNodeVisitor>>,
+  RuleVisitor {}
 
 export type CSSRuleDefinitionTypeOptions = {
-  RuleOptions: unknown[]
-  MessageIds: string
   ExtRuleDocs: Record<string, unknown>
+  MessageIds: string
+  RuleOptions: unknown[]
 };
 
 /**
@@ -56,17 +56,17 @@ export type CSSRuleDefinition<
   Options extends Partial<CSSRuleDefinitionTypeOptions> = object,
 > = RuleDefinition<
   // Language specific type options (non-configurable)
-  {
-    LangOptions: CSSLanguageOptions
-    Code: CSSSourceCode
-    Visitor: CSSRuleVisitor
-    Node: CssNodePlain
-  } & Required<
+  Required<
     // Rule specific type options (custom)
     Options &
       // Rule specific type options (defaults)
     Omit<CSSRuleDefinitionTypeOptions, keyof Options>
-  >
+  > & {
+    Code: CSSSourceCode
+    LangOptions: CSSLanguageOptions
+    Node: CssNodePlain
+    Visitor: CSSRuleVisitor
+  }
 >;
 
 /**
@@ -74,10 +74,10 @@ export type CSSRuleDefinition<
  * to avoid TS2742 declaration portability issues.
  */
 export interface Plugin {
-  meta: { name: string; version: string }
-  languages: Record<string, Language>
-  rules: Record<string, RuleDefinition>
   configs: Record<string, Linter.Config>
+  languages: Record<string, Language>
+  meta: { name: string; version: string }
+  rules: Record<string, RuleDefinition>
 }
 
 /**

--- a/src/utils/ast.ts
+++ b/src/utils/ast.ts
@@ -8,11 +8,11 @@ import { CSSSourceCode } from '@eslint/css';
  * Type for CSS rule context - matches what CSS rules expect
  */
 export type CSSRuleContext = RuleContext<{
-  LangOptions: CSSLanguageOptions
   Code: CSSSourceCode
-  RuleOptions: unknown[]
-  Node: CssNodePlain
+  LangOptions: CSSLanguageOptions
   MessageIds: string
+  Node: CssNodePlain
+  RuleOptions: unknown[]
 }>;
 
 /**
@@ -107,9 +107,9 @@ export function getCSSContext<T extends RuleContextTypeOptions = RuleContextType
   }
 
   const sourceCodeObject = sourceCode as unknown as {
+    [key: string]: unknown
     ast?: { type?: string }
     text?: unknown
-    [key: string]: unknown
   };
 
   // If we can't access the AST or text, it's not CSS content

--- a/src/utils/browser-compat.ts
+++ b/src/utils/browser-compat.ts
@@ -6,10 +6,10 @@
 export type BaselineStatus = 'limited-availability' | 'newly-available' | 'widely-available';
 
 export interface CSSFeature {
-  name: string
-  status: BaselineStatus
   alternativeSuggestion?: string
   mdn?: string
+  name: string
+  status: BaselineStatus
 }
 
 /**
@@ -492,6 +492,7 @@ export function getFeatureStatus(
  * Options for use-baseline rule
  */
 export interface UseBaselineOptions {
+  ignore?: string[]
   /**
    * Strictness level for baseline checking
    * - 'limited': Only flag limited availability features (default)
@@ -499,5 +500,4 @@ export interface UseBaselineOptions {
    * - 'ignore': List of features to ignore
    */
   strictness?: 'limited' | 'newly'
-  ignore?: string[]
 }

--- a/src/utils/tailwind.ts
+++ b/src/utils/tailwind.ts
@@ -67,9 +67,9 @@ export function countArbitraryValues(value: string): number {
  * Parse a Tailwind utility class into its components
  */
 export interface ParsedUtility {
+  arbitraryValue?: string
   modifiers: string[]
   utility: string
-  arbitraryValue?: string
 }
 
 export function parseUtilityClass(className: string): ParsedUtility {

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -6,17 +6,17 @@ import { getChildrenOfType, getDeclarations, isAtRule } from './ast';
  * Represents a theme value from `@theme` blocks
  */
 export interface ThemeValue {
+  loc: CssLocationRange
   name: string
   value: string
-  loc: CssLocationRange
 }
 
 /**
  * Represents a theme token with similarity score
  */
 interface TokenSuggestion {
-  token: string
   score: number
+  token: string
 }
 
 /**

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -15,6 +15,6 @@ export { type SyntaxConfig } from '@eslint/css-tree';
  * Used for similarity calculations
  */
 export interface StringWithDistance {
-  value: string
   distance: number
+  value: string
 }


### PR DESCRIPTION
## Summary

Upgrade `@poupe/eslint-config` to 0.9.1, drop the now-redundant
local perfectionist override, fix `pkg-pr-new` PR comment
permissions, and cut v0.3.1.

- **fix(ci)**: Add `pull-requests: write` permission to
  `build.yml` so `pkg-pr-new` can post install comments on PRs.
  Mirrors poupe-ui/eslint-config@cd89d82.
- **chore(deps)**: `@poupe/eslint-config` ~0.9.0 → ~0.9.1.
  eslint-config 0.9.1 ships `eslint-plugin-perfectionist` v5
  with `partitionByNewLine` enabled on `sort-exports` and
  `sort-named-exports`, so the local override in
  `eslint.config.mjs` (carrying a TODO from when this was a
  workaround) is removed.
- **chore(deps)**: Drop the direct `eslint-plugin-perfectionist`
  ^4.15.1 devDep — it's now provided transitively by eslint-config
  (v5). Keeping the v4 pin would have conflicted with the v5
  range eslint-config requires.
- One-time source formatting churn across 22 files from
  perfectionist v5's new recommended sort rules
  (`sort-interfaces`, `sort-object-types`,
  `sort-heritage-clauses`, `sort-intersection-types`) — pure
  alphabetical reordering of interface/type fields, no semantic
  changes.
- **release**: Bump version to 0.3.1.

Mirrors the @poupe/eslint-config v0.9.1 release (poupe-ui/eslint-config#229).

## Test plan

- [ ] CI passes (build, lint, type-check, tests)
- [ ] `pnpm precommit` passes locally (verified before push)
- [ ] `pkg-pr-new` posts install comment on this PR (validates
      the workflow permission fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Bumped package version to 0.3.1.
  * Updated `@poupe/eslint-config` from ~0.9.0 to ~0.9.1; perfectionist features now provided transitively.
  * Removed direct `eslint-plugin-perfectionist` dependency.

* **Refactor**
  * Reorganized type parameter declarations across rule and utility modules for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->