### PR TITLE
chore: scope CI permissions and document customSyntax error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,13 +7,15 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   make:
     runs-on: ubuntu-latest
     # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Documentation
+
+- **README**: Add troubleshooting entry for the `customSyntax`
+  `TypeError` raised when an older `@eslint/css` (< 1.0) is resolved
+  against the plugin — typically because `@poupe/eslint-config`
+  is pinned below `~0.9.1`
+
 ## [0.3.1] - 2026-04-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -532,6 +532,31 @@ export default [
 ];
 ```
 
+### `TypeError: ... Expected an object value for 'customSyntax' option`
+
+Full error:
+
+```text
+TypeError: Key "languageOptions": Expected an object value for
+'customSyntax' option.
+```
+
+This means an older `@eslint/css` (< 1.0) was resolved against the
+plugin. Versions before 1.0 only accept a plain object for
+`customSyntax`, while this plugin passes a `SyntaxExtensionCallback`
+(supported since `@eslint/css` 1.0). Although the plugin declares
+`@eslint/css ^1.1.0` as a peer dependency, pnpm only emits a warning
+when another package in the tree pins an older version, so the
+mismatch can slip through at install time and only surface when ESLint
+loads the config.
+
+To fix it, ensure `@eslint/css ^1.1.0` wins resolution in your project:
+
+- If you use [`@poupe/eslint-config`][eslint-config], upgrade to
+  `~0.9.1` or later — earlier versions pinned `@eslint/css 0.14.x`.
+- Otherwise, audit your lockfile (`pnpm why @eslint/css`) for the
+  package forcing the older version and upgrade or override it.
+
 ## Contributing
 
 Contributions are welcome! Please read our


### PR DESCRIPTION
## Summary

Two unrelated housekeeping changes:

1. **`fix(ci): scope pull-requests permission to job in build workflow`**

   Move `pull-requests: write` from the workflow-level
   `permissions:` block in `.github/workflows/build.yml` down to
   the `make` job (least privilege). The job needs it so
   `pkg-pr-new` can post install comments on pull requests;
   nothing else in this workflow does. Job-level `permissions:`
   overrides workflow-level entirely (it does not merge), so
   `contents: read` is re-declared on the job to keep
   `actions/checkout` working.

   Mirrors the same fix being applied on `@poupe/eslint-config`.

2. **`docs: troubleshoot customSyntax TypeError from old @eslint/css`**

   Add a README troubleshooting entry for:

   ```text
   TypeError: Key "languageOptions": Expected an object value for
   'customSyntax' option.
   ```

   This is raised when an older `@eslint/css` (< 1.0) is resolved
   against the plugin. Versions before 1.0 only accept a plain
   object for `customSyntax`, while this plugin passes a
   `SyntaxExtensionCallback` (supported since `@eslint/css` 1.0).
   The peer-dep range `^1.1.0` is only a pnpm warning, so the
   mismatch can slip through install and only surface at config
   load.

   The new section points users at the typical culprit
   (`@poupe/eslint-config` pinned below `~0.9.1`, which dragged
   in `@eslint/css 0.14.x`) and at `pnpm why @eslint/css` for
   tracking down other offenders. CHANGELOG `[Unreleased]`
   updated to match.

## Test plan

- [ ] CI green on this PR
- [ ] `pkg-pr-new` install comment still posted on the PR
- [ ] README troubleshooting section renders cleanly in the PR
      preview


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Added troubleshooting guide for ESLint `customSyntax` type errors in configurations
- Documented steps to resolve dependency version conflicts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->